### PR TITLE
Refactor and make item content available dynamically

### DIFF
--- a/GovukRegistersApiClientNet.Implementation/Commands/AddItemCommand.cs
+++ b/GovukRegistersApiClientNet.Implementation/Commands/AddItemCommand.cs
@@ -1,0 +1,31 @@
+﻿using GovukRegistersApiClientNet.Implementation.Interfaces;
+using GovukRegistersApiClientNet.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovukRegistersApiClientNet.Implementation.Commands
+{
+    public class AddItemCommandHandler : IRsfCommandHandler
+    {
+        private readonly ISha256Service _sha256Service;
+
+        public AddItemCommandHandler(ISha256Service sha256Service)
+        {
+            _sha256Service = sha256Service;
+        }
+
+        public string GetName()
+        {
+            return "add-item";
+        }
+
+        public void Parse(string[] rsfComponents, IDataStore dataStore)
+        {
+            var json = rsfComponents[1];
+            var hash = $"sha-256:{ _sha256Service.ComputeSha256Hash(json).ToLower() }";
+
+            dataStore.AddItem(new Item(hash, json));
+        }
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/Commands/AddItemCommand.cs
+++ b/GovukRegistersApiClientNet.Implementation/Commands/AddItemCommand.cs
@@ -8,11 +8,11 @@ namespace GovukRegistersApiClientNet.Implementation.Commands
 {
     public class AddItemCommandHandler : IRsfCommandHandler
     {
-        private readonly ISha256Service _sha256Service;
+        private readonly IItemFactory _itemFactory;
 
-        public AddItemCommandHandler(ISha256Service sha256Service)
+        public AddItemCommandHandler(IItemFactory itemFactory)
         {
-            _sha256Service = sha256Service;
+            _itemFactory = itemFactory;
         }
 
         public string GetName()
@@ -23,9 +23,8 @@ namespace GovukRegistersApiClientNet.Implementation.Commands
         public void Parse(string[] rsfComponents, IDataStore dataStore)
         {
             var json = rsfComponents[1];
-            var hash = $"sha-256:{ _sha256Service.ComputeSha256Hash(json).ToLower() }";
 
-            dataStore.AddItem(new Item(hash, json));
+            dataStore.AddItem(_itemFactory.CreateItem(json));
         }
     }
 }

--- a/GovukRegistersApiClientNet.Implementation/Commands/AppendEntryCommand.cs
+++ b/GovukRegistersApiClientNet.Implementation/Commands/AppendEntryCommand.cs
@@ -1,0 +1,34 @@
+﻿using GovukRegistersApiClientNet.Implementation.Interfaces;
+using GovukRegistersApiClientNet.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovukRegistersApiClientNet.Implementation.Commands
+{
+    public class AppendEntryCommandHandler : IRsfCommandHandler
+    {
+        private readonly Dictionary<string, int> _entryNumbers;
+
+        public AppendEntryCommandHandler(Dictionary<string, int> entryNumbers)
+        {
+            _entryNumbers = entryNumbers;
+        }
+
+        public string GetName()
+        {
+            return "append-entry";
+        }
+
+        public void Parse(string[] rsfComponents, IDataStore dataStore)
+        {
+            var entryType = rsfComponents[1];
+            var key = rsfComponents[2];
+            var timestamp = DateTime.Parse(rsfComponents[3]);
+            var itemHash = rsfComponents[4];
+            var entryNumber = ++_entryNumbers[entryType];
+
+            dataStore.AppendEntry(new Entry(entryNumber, entryType, key, itemHash, timestamp));
+        }
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/Commands/AssertRootHashCommand.cs
+++ b/GovukRegistersApiClientNet.Implementation/Commands/AssertRootHashCommand.cs
@@ -1,0 +1,20 @@
+﻿using GovukRegistersApiClientNet.Implementation.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovukRegistersApiClientNet.Implementation.Commands
+{
+    public class AssertRootHashCommandHandler : IRsfCommandHandler
+    {
+        public string GetName()
+        {
+            return "assert-root-hash";
+        }
+
+        public void Parse(string[] rsfComponents, IDataStore dataStore)
+        {
+            // To be implemented
+        }
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/Extensions/ServiceCollectionExtensions.cs
+++ b/GovukRegistersApiClientNet.Implementation/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 ﻿using GovukRegistersApiClientNet.Implementation.Factories;
+using GovukRegistersApiClientNet.Implementation.Helpers;
 using GovukRegistersApiClientNet.Implementation.Interfaces;
 using GovukRegistersApiClientNet.Implementation.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -16,7 +18,9 @@ namespace GovukRegistersApiClientNet.Implementation.Extensions
                 .AddSingleton<IRsfDownloadService, RsfDownloadService>()
                 .AddSingleton<IRsfUpdateService, RsfUpdateService>()
                 .AddSingleton<ISha256Service, Sha256Service>()
-                .AddSingleton<IRegisterClientFactory, RegisterClientFactory>();
+                .AddSingleton<IRegisterClientFactory, RegisterClientFactory>()
+                .AddSingleton<IItemFactory, ItemFactory>()
+                .AddSingleton<JsonConverter, DashToUnderscoreJsonConverter>();
 
             return services;
         }

--- a/GovukRegistersApiClientNet.Implementation/Factories/ItemFactory.cs
+++ b/GovukRegistersApiClientNet.Implementation/Factories/ItemFactory.cs
@@ -1,0 +1,30 @@
+﻿using GovukRegistersApiClientNet.Implementation.Helpers;
+using GovukRegistersApiClientNet.Implementation.Interfaces;
+using GovukRegistersApiClientNet.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovukRegistersApiClientNet.Implementation.Factories
+{
+    public class ItemFactory : IItemFactory
+    {
+        private readonly ISha256Service _sha256Service;
+        private readonly JsonConverter _jsonConverter;
+
+        public ItemFactory(ISha256Service sha256Service, JsonConverter jsonConverter)
+        {
+            _sha256Service = sha256Service;
+            _jsonConverter = jsonConverter;
+        }
+
+        public Item CreateItem(string json)
+        {
+            var hash = $"sha-256:{ _sha256Service.ComputeSha256Hash(json).ToLower() }";
+            dynamic data = JsonConvert.DeserializeObject<dynamic>(json, _jsonConverter);
+
+            return new Item(hash, data);
+        }
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/GovukRegistersApiClientNet.Implementation.csproj
+++ b/GovukRegistersApiClientNet.Implementation/GovukRegistersApiClientNet.Implementation.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>

--- a/GovukRegistersApiClientNet.Implementation/Helpers/DashToUnderscoreJsonConverter.cs
+++ b/GovukRegistersApiClientNet.Implementation/Helpers/DashToUnderscoreJsonConverter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GovukRegistersApiClientNet.Implementation.Helpers
+{
+    public class DashToUnderscoreJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jObject = JObject.Load(reader);
+
+            foreach (var property in jObject.Properties().ToList())
+            {
+                if (property.Name.Contains("-"))
+                {
+                    var name = property.Name.Replace("-", "_");
+                    property.Replace(new JProperty(name, property.Value));
+                }
+            }
+
+            return jObject;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/Interfaces/IItemFactory.cs
+++ b/GovukRegistersApiClientNet.Implementation/Interfaces/IItemFactory.cs
@@ -1,0 +1,12 @@
+﻿using GovukRegistersApiClientNet.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovukRegistersApiClientNet.Implementation.Interfaces
+{
+    public interface IItemFactory
+    {
+        Item CreateItem(string json);
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/Interfaces/IRsfParseCommand.cs
+++ b/GovukRegistersApiClientNet.Implementation/Interfaces/IRsfParseCommand.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovukRegistersApiClientNet.Implementation.Interfaces
+{
+    public interface IRsfCommandHandler
+    {
+        string GetName();
+
+        void Parse(string[] rsfComponents, IDataStore dataStore);
+    }
+}

--- a/GovukRegistersApiClientNet.Implementation/Models/Item.cs
+++ b/GovukRegistersApiClientNet.Implementation/Models/Item.cs
@@ -1,17 +1,14 @@
-﻿using Newtonsoft.Json;
-using System.Collections.Generic;
-
-namespace GovukRegistersApiClientNet.Models
+﻿namespace GovukRegistersApiClientNet.Models
 {
     public class Item : IItem
     {
         public string Hash { get; set; }
-        public Dictionary<string, dynamic> Data { get; set; }
+        public dynamic Data { get; set; }
 
-        public Item(string hash, string json)
+        public Item(string hash, dynamic data)
         {
             Hash = hash;
-            Data = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(json);
+            Data = data;
         }
     }
 }

--- a/GovukRegistersApiClientNet.Implementation/Services/RsfUpdateService.cs
+++ b/GovukRegistersApiClientNet.Implementation/Services/RsfUpdateService.cs
@@ -10,11 +10,11 @@ namespace GovukRegistersApiClientNet.Implementation.Services
 {
     public class RsfUpdateService : IRsfUpdateService
     {
-        private readonly ISha256Service _sha256Service;
+        private readonly IItemFactory _itemFactory;
 
-        public RsfUpdateService(ISha256Service sha256Service)
+        public RsfUpdateService(IItemFactory itemFactory)
         {
-            _sha256Service = sha256Service;
+            _itemFactory = itemFactory;
         }
 
         public void UpdateData(string rsf, IDataStore dataStore)
@@ -29,7 +29,7 @@ namespace GovukRegistersApiClientNet.Implementation.Services
 
             var commandHandlers = new Dictionary<string, IRsfCommandHandler>
             {
-                { "add-item", new AddItemCommandHandler(_sha256Service) },
+                { "add-item", new AddItemCommandHandler(_itemFactory) },
                 { "append-entry", new AppendEntryCommandHandler(entryNumbers) },
                 { "assert-root-hash", new AssertRootHashCommandHandler() }
             };

--- a/GovukRegistersApiClientNet.Test/RegisterClientTest.cs
+++ b/GovukRegistersApiClientNet.Test/RegisterClientTest.cs
@@ -6,6 +6,8 @@ using GovukRegistersApiClientNet.Enums;
 using System;
 using GovukRegistersApiClientNet.Implementation;
 using GovukRegistersApiClientNet.Implementation.Services;
+using GovukRegistersApiClientNet.Implementation.Factories;
+using GovukRegistersApiClientNet.Implementation.Helpers;
 
 namespace GovukRegistersApiClientNet.Test
 {
@@ -16,7 +18,8 @@ namespace GovukRegistersApiClientNet.Test
 
         public RegisterClientTest()
         {
-            Client = new RegisterClient("country", Phase.ReadyToUse, new InMemoryDataStore(), new RsfDownloadService(), new RsfUpdateService(new Sha256Service()));
+            var sha256Service = new Sha256Service();
+            Client = new RegisterClient("country", Phase.ReadyToUse, new InMemoryDataStore(), new RsfDownloadService(), new RsfUpdateService(new ItemFactory(sha256Service, new DashToUnderscoreJsonConverter())));
         }
 
         [TestMethod]

--- a/GovukRegistersApiClientNet/Models/IItem.cs
+++ b/GovukRegistersApiClientNet/Models/IItem.cs
@@ -5,6 +5,6 @@ namespace GovukRegistersApiClientNet.Models
     public interface IItem
     {
         string Hash { get; }
-        Dictionary<string, dynamic> Data { get; }
+        dynamic Data { get; }
     }
 }


### PR DESCRIPTION
This PR introduces refactors to introduce the command pattern to the task of parsing RSF, in addition to making item properties available dynamically on `Item`s. 

For example, to access the `name` and `official-name` for a country, you would write:
`record.Item.Data.name;`
`record.Item.Data.official_name;`

Previous, this was:
`record.Item.Data["name"];`
`record.Item.Data["official-name"];`